### PR TITLE
PLAT-8636-use-internal-docker-mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM docker.twtools.io/docker_io/library/ruby:2.6-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Closes PLAT-8636.